### PR TITLE
Small test of implementation of random-order on classes

### DIFF
--- a/pulp_2_tests/tests/python/api_v2/test_crud.py
+++ b/pulp_2_tests/tests/python/api_v2/test_crud.py
@@ -6,6 +6,8 @@ from pulp_smash.pulp2.utils import BaseAPICrudTestCase
 from pulp_2_tests.tests.python.api_v2.utils import gen_repo
 from pulp_2_tests.tests.python.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
+import pytest
+pytestmark = pytest.mark.random_order(disabled=True)
 
 class CRUDTestCase(BaseAPICrudTestCase):
     """Test that one can create, update, read and delete a test case."""

--- a/pulp_2_tests/tests/python/api_v2/test_duplicate_uploads.py
+++ b/pulp_2_tests/tests/python/api_v2/test_duplicate_uploads.py
@@ -26,6 +26,8 @@ from pulp_2_tests.constants import PYTHON_EGG_URL
 from pulp_2_tests.tests.python.api_v2.utils import gen_repo
 from pulp_2_tests.tests.python.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
+import pytest
+pytestmark = pytest.mark.random_order(disabled=True)
 
 class DuplicateUploadsTestCase(BaseAPITestCase, DuplicateUploadsMixin):
     """Test how well Pulp can deal with duplicate content unit uploads."""

--- a/pulp_2_tests/tests/python/api_v2/test_sync_publish.py
+++ b/pulp_2_tests/tests/python/api_v2/test_sync_publish.py
@@ -24,6 +24,8 @@ from pulp_2_tests.tests.python.api_v2.utils import gen_distributor, gen_repo
 from pulp_2_tests.tests.python.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_2_tests.tests.python.utils import skip_if
 
+import pytest
+pytestmark = pytest.mark.random_order(disabled=True)
 
 class BaseTestCase(unittest.TestCase):
     """A base class for the test cases in this module.

--- a/pulp_2_tests/tests/rpm/api_v2/test_crud.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_crud.py
@@ -5,6 +5,7 @@ For information on repository CRUD operations, see `Creation, Deletion and
 Configuration
 <http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/cud.html>`_.
 """
+import pytest
 import os
 import unittest
 from urllib.parse import urljoin


### PR DESCRIPTION
# Temporary Commit Example

Example of changes to be made to enable `random-order`.

# Example Test Output and Ordering

Pulling and running this from this branch will yield results similar to the following:

```
(pytest) [herring@redherring api_v2]$ pytest --random-order -vvv --disable-warnings
========================================== test session starts ==========================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.7.0, pluggy-0.8.0 -- /home/herring/envs/pytest/bin/python3
cachedir: .pytest_cache
Using --random-order-bucket=module
Using --random-order-seed=370187

rootdir: /home/herring/git/Pulp-2-Tests, inifile:
plugins: random-order-1.0.4
collected 22 items                                                                                      

test_crud.py::CRUDTestCase::test_create <- ../pulp-smash/pulp_smash/pulp2/utils.py PASSED         [  4%]
test_crud.py::CRUDTestCase::test_importer_config <- ../pulp-smash/pulp_smash/pulp2/utils.py PASSED [  9%]
test_crud.py::CRUDTestCase::test_importer_type_id <- ../pulp-smash/pulp_smash/pulp2/utils.py PASSED [ 13%]
test_crud.py::CRUDTestCase::test_number_importers <- ../pulp-smash/pulp_smash/pulp2/utils.py PASSED [ 18%]
test_crud.py::CRUDTestCase::test_read <- ../pulp-smash/pulp_smash/pulp2/utils.py PASSED           [ 22%]
test_crud.py::CRUDTestCase::test_status_codes <- ../pulp-smash/pulp_smash/pulp2/utils.py PASSED   [ 27%]
test_crud.py::CRUDTestCase::test_update <- ../pulp-smash/pulp_smash/pulp2/utils.py PASSED         [ 31%]
test_sync_publish.py::UploadTestCase::test_01_first_repo PASSED                                   [ 36%]
test_sync_publish.py::UploadTestCase::test_02_second_repo PASSED                                  [ 40%]
test_duplicate_uploads.py::DuplicateUploadsTestCase::test_01_first_upload <- ../pulp-smash/pulp_smash/pulp2/utils.py PASSED [ 45%]
test_duplicate_uploads.py::DuplicateUploadsTestCase::test_02_second_upload <- ../pulp-smash/pulp_smash/pulp2/utils.py PASSED [ 50%]
test_sync_publish.py::BaseTestCase::test_01_first_repo SKIPPED                                    [ 54%]
test_sync_publish.py::BaseTestCase::test_02_second_repo SKIPPED                                   [ 59%]
test_crud.py::BaseAPICrudTestCase::test_create <- ../pulp-smash/pulp_smash/pulp2/utils.py SKIPPED [ 63%]
test_crud.py::BaseAPICrudTestCase::test_importer_config <- ../pulp-smash/pulp_smash/pulp2/utils.py SKIPPED [ 68%]
test_crud.py::BaseAPICrudTestCase::test_importer_type_id <- ../pulp-smash/pulp_smash/pulp2/utils.py SKIPPED [ 72%]
test_crud.py::BaseAPICrudTestCase::test_number_importers <- ../pulp-smash/pulp_smash/pulp2/utils.py SKIPPED [ 77%]
test_crud.py::BaseAPICrudTestCase::test_read <- ../pulp-smash/pulp_smash/pulp2/utils.py SKIPPED   [ 81%]
test_crud.py::BaseAPICrudTestCase::test_status_codes <- ../pulp-smash/pulp_smash/pulp2/utils.py SKIPPED [ 86%]
test_crud.py::BaseAPICrudTestCase::test_update <- ../pulp-smash/pulp_smash/pulp2/utils.py SKIPPED [ 90%]
test_sync_publish.py::SyncTestCase::test_01_first_repo PASSED                                     [ 95%]
test_sync_publish.py::SyncTestCase::test_02_second_repo PASSED                                    [100%]

========================== 13 passed, 9 skipped, 18 warnings in 22.36 seconds ===========================
(pytest) [herring@redherring api_v2]$
```
Above, it is demonstrated that all of the content of `test_crud.py::CRUDTestCase` is ran at one time. However, all the classes in `test_crud.py` are not run sequentially. The execution is intermingled with `test_sync_publish.py`.

This executoin style also has the expected result of not polluting the test order and causing errors from interrupted test orders.

# Iteration Testing
I have ran this small sub-set of modified tests in the following batches:
* Unmodified to ensure there were no initial errors
* With all tests modified in a single iteration (no additional errors)
* In a loop of 100 iterations with no failures [0]

# Summary
If this execution style is desirable, the two lines (appropriately placed to coding standards), would need to be added on each test to enable `--random-order` on the pytest command line on ci:

```
import pytest
pytestmark = pytest.mark.random_order(disabled=True)
```

# References
[0] - https://paste.fedoraproject.org/paste/SI08prZ6~zwWcR~FIPs15A